### PR TITLE
fact factory, OS and Puppet support and testing improved

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,30 @@
+---
+  mock_with: ':rspec'
+  .travis.yml:
+    docker_defaults:
+      bundler_args: --with system_tests
+    docker_sets:
+      - set: centos-7
+  Gemfile:
+    required:
+      ':system_tests':
+        - gem: 'puppet-module-posix-system-r#{minor_version}'
+          platforms: ruby
+        - gem: 'puppet-module-win-system-r#{minor_version}'
+          platforms:
+            - mswin
+            - mingw
+            - x64_mingw
+        - gem: beaker
+          version: '~> 3.13'
+          from_env: BEAKER_VERSION
+        - gem: beaker-abs
+          from_env: BEAKER_ABS_VERSION
+          version: '~> 0.1'
+        - gem: beaker-pe
+        - gem: beaker-hostgenerator
+          from_env: BEAKER_HOSTGENERATOR_VERSION
+        - gem: beaker-rspec
+          from_env: BEAKER_RSPEC_VERSION
+        - gem: 'rspec-json_expectations'
+          version: '~> 2.1'

--- a/.sync.yml
+++ b/.sync.yml
@@ -5,6 +5,11 @@
       bundler_args: --with system_tests
     docker_sets:
       - set: centos-7
+      - set: debian-8
+      - set: debian-9
+    includes:
+      - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+        rvm: 2.5.1
   Gemfile:
     required:
       ':system_tests':

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,22 @@ matrix:
       services: docker
       sudo: required
     -
+      bundler_args: --with system_tests
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=debian-8 BEAKER_TESTMODE=apply
+      rvm: 2.5.0
+      script: bundle exec rake beaker
+      services: docker
+      sudo: required
+    -
+      bundler_args: --with system_tests
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=debian-9 BEAKER_TESTMODE=apply
+      rvm: 2.5.0
+      script: bundle exec rake beaker
+      services: docker
+      sudo: required
+    -
       env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
       env: CHECK=parallel_spec
@@ -38,6 +54,9 @@ matrix:
     -
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
       rvm: 2.1.9
+    -
+      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+      rvm: 2.5.1
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,14 @@ matrix:
   fast_finish: true
   include:
     -
+      bundler_args: --with system_tests
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=centos-7 BEAKER_TESTMODE=apply
+      rvm: 2.5.0
+      script: bundle exec rake beaker
+      services: docker
+      sudo: required
+    -
       env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
       env: CHECK=parallel_spec

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,16 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
+group :system_tests do
+  gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}",                              require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.13')
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
+  gem "beaker-pe",                                                               require: false
+  gem "beaker-hostgenerator"
+  gem "beaker-rspec"
+  gem "rspec-json_expectations", '~> 2.1',                                       require: false
+end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
 facter_version = ENV['FACTER_GEM_VERSION']

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -13,8 +13,8 @@
 # @param value The value of the fact (can include structured facts)
 # @param ensure Set to absent to explicitly remove the custom fact - behaves like a normal ensure parameter
 define static_custom_facts::fact (
-  Variant[String, Array, Hash, Numeric, Boolean] $value,
-  Enum['present', 'absent', 'file']              $ensure = present,
+  Data                              $value,
+  Enum['present', 'absent', 'file'] $ensure = present,
 ) {
   $yaml_value = {
     $name => $value,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,16 @@
 # @example Delcaring the class
 #   include ::static_custom_facts
 #
+# @example defining static facts via hiera
+#   static_custom_facts::custom_facts:
+#     static1: Hello world
+#     static2:
+#       - Hello
+#       - world
+#     static3:
+#       what: Hello
+#       whom: world
+#
 # @param parent_dirs Parent directories of facts_path to create
 # @param facts_path The location where custom facts will be installed
 # @param facts_path_owner The owner of the custom facts directory (not created by this module)
@@ -12,12 +22,12 @@
 # @param purge_unmanaged If facts in the facts_path not managed by puppet are deleted or not
 # @param custom_facts A hash of facts that should be created (useful with hiera)
 class static_custom_facts(
-  Array   $parent_dirs      = $static_custom_facts::params::parent_dirs,
-  String  $facts_path       = $static_custom_facts::params::facts_path,
-  String  $facts_path_owner = $static_custom_facts::params::facts_path_owner,
-  String  $facts_path_group = $static_custom_facts::params::facts_path_group,
-  Boolean $purge_unmanaged  = $static_custom_facts::params::purge_unmanaged,
-  Hash    $custom_facts     = {},
+  Array             $parent_dirs      = $static_custom_facts::params::parent_dirs,
+  String            $facts_path       = $static_custom_facts::params::facts_path,
+  String            $facts_path_owner = $static_custom_facts::params::facts_path_owner,
+  String            $facts_path_group = $static_custom_facts::params::facts_path_group,
+  Boolean           $purge_unmanaged  = $static_custom_facts::params::purge_unmanaged,
+  Hash[String,Data] $custom_facts     = {},
 ) inherits static_custom_facts::params {
 
   case $::kernel {
@@ -53,5 +63,14 @@ class static_custom_facts(
     }
   }
 
-  create_resources('static_custom_facts::fact', $custom_facts)
+  $custom_facts.each |$name, $value| {
+    $ensure = defined('$value') ? {
+      true    => 'present',
+      default => 'absent',
+    }
+    static_custom_facts::fact { $name:
+      ensure => $ensure,
+      value  => $value,
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     }
   ],
   "tags": [

--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,13 @@
       ]
     },
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "5",

--- a/spec/acceptance/001_basic_spec.rb
+++ b/spec/acceptance/001_basic_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper_acceptance'
+require 'rspec/json_expectations'
 
 describe 'static_custom_facts class' do
   context 'default parameters' do
@@ -21,6 +22,18 @@ describe 'static_custom_facts class' do
       it { is_expected.to contain('---') }
       it { is_expected.to contain('user@example.com') }
       it { is_expected.not_to contain('max_procs: !ruby') }
+    end
+
+    describe 'reported facts contain the correct custom values' do
+      subject(:puppet_facts) { command('puppet facts --render-as JSON') }
+
+      its(:stdout) do
+        is_expected.to include_json(
+          'values' => {
+            'responsible_people' => ['user@example.com'],
+          },
+        )
+      end
     end
   end
 end

--- a/spec/acceptance/nodesets/debian-8.yml
+++ b/spec/acceptance/nodesets/debian-8.yml
@@ -1,0 +1,13 @@
+---
+HOSTS:
+  debian-8-x64:
+    platform: debian-8-amd64
+    hypervisor: docker
+    image: debian:8
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof'
+      - 'locale-gen en_US en_US.UTF-8'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/nodesets/debian-9.yml
+++ b/spec/acceptance/nodesets/debian-9.yml
@@ -1,0 +1,14 @@
+---
+HOSTS:
+  debian-9-x64:
+    platform: debian-9-amd64
+    hypervisor: docker
+    image: debian:9
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y cron locales-all net-tools wget systemd-sysv git'
+      - 'systemctl mask getty@tty1.service getty-static.service'
+CONFIG:
+  trace_limit: 200
+  masterless: true

--- a/spec/classes/static_custom_facts_spec.rb
+++ b/spec/classes/static_custom_facts_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 describe 'static_custom_facts', type: :class do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'defaults' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('static_custom_facts') }
+        it { is_expected.to contain_class('static_custom_facts::params') }
+        it do
+          is_expected.to contain_file('facts-directory').with(
+            ensure: 'directory',
+          )
+        end
+      end  
+    end
+  end
+
   context 'On a Linux system' do
     let :facts do
       {

--- a/spec/classes/static_custom_facts_spec.rb
+++ b/spec/classes/static_custom_facts_spec.rb
@@ -14,7 +14,7 @@ describe 'static_custom_facts', type: :class do
             ensure: 'directory',
           )
         end
-      end  
+      end
     end
   end
 

--- a/spec/classes/static_custom_facts_spec.rb
+++ b/spec/classes/static_custom_facts_spec.rb
@@ -35,6 +35,14 @@ describe 'static_custom_facts', type: :class do
       it { is_expected.to contain_class('static_custom_facts') }
       it { is_expected.to contain_class('static_custom_facts::params') }
       it do
+        is_expected.to contain_file('/etc/puppetlabs/facter').with(
+          ensure: 'directory',
+          path: '/etc/puppetlabs/facter',
+          owner: 'root',
+          group: 'wheel',
+        )
+      end
+      it do
         is_expected.to contain_file('facts-directory').with(
           ensure: 'directory',
           path: '/etc/puppetlabs/facter/facts.d',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 


### PR DESCRIPTION
The new factory does not involve create_resources any more and simplifies the necessary hiera structure.

Coverage of spec tests has been improved. Support for Puppet-6 and Debian added. Acceptance tests have been improved and enabled for centos-7, debian-8 and debian-9.